### PR TITLE
Arreglos de pestaña de Jobs en Ubiquo

### DIFF
--- a/lib/ubiquo/filtered_search.rb
+++ b/lib/ubiquo/filtered_search.rb
@@ -82,6 +82,8 @@ module Ubiquo
       #  >> Book.paginated_filtered_search(params)
       #  >> Book.paginated_filtered_search(params, :scopes => [ :text ])
       def filtered_search(params = {}, options = {})
+        return job_filtered_search(params, options) if respond_to? :job_filtered_search
+
         scopes = select_scopes(params, options[:scopes])
         scopes.inject(self) do |results, pair|
           pair.last.blank? ? results : results.send(pair.first, pair.last)


### PR DESCRIPTION
Parte de https://github.com/taigabe/gara-web/issues/622

En esta tarea se arregla:
- Que los filtros funcionen (junto con PR en ubiquo_jobs y gara-web)

Se ejecuta el método por el alias generado en https://github.com/taigabe/ubiquo_jobs/pull/3/commits/91b69578435998795fafa60ad62e42c4bf550ed5. Ver la PR de ubiquo_jobs

Esta pull request depende de otras dos:
- ubiquo_jobs -> https://github.com/taigabe/ubiquo_jobs/pull/3
- gara-web -> https://github.com/taigabe/gara-web/pull/635